### PR TITLE
ci: stop cancelling CI when buildtex auto-pushes (fixes stuck required checks)

### DIFF
--- a/.github/workflows/buildtex.yml
+++ b/.github/workflows/buildtex.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,15 @@ on:
   pull_request:
     branches: ["main"]
 
+# Do not cancel in-progress runs: docs PRs trigger buildtex, which auto-pushes PDFs and
+# re-fires pull_request. Cancelling the previous CI run often kills long LaTeX matrix jobs
+# before the final "CI" job posts a status → branch protection stuck on "Expected".
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   detect-changes:


### PR DESCRIPTION
## Problem

Docs PRs (e.g. [#336](https://github.com/hitchly/hitchly/pull/336)) run **CI** (long LaTeX matrix) and **buildtex** (compiles PDFs). `buildtex` can **push** back to the PR branch, which fires another `pull_request` sync.

With `cancel-in-progress: true` on **CI**, that new event **cancels** the in-flight workflow before the final aggregate **CI** job finishes. Branch protection then stays on **Expected — Waiting for status to be reported** for the **CI** check.

## Change

- Set `cancel-in-progress: false` for both **CI** and **buildtex** concurrency groups (same reasoning for buildtex races).
- Add `permissions: contents: read` on the CI workflow.

## After merge

Merge this to `main`, then on [#336](https://github.com/hitchly/hitchly/pull/336) use **Update branch** and **Re-run all jobs** (or push an empty commit) so a full run can complete without being cancelled mid-matrix.